### PR TITLE
Fix Azure startup failure caused by missing migration

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-ef": {
+      "version": "10.0.3",
+      "commands": [
+        "dotnet-ef"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/.github/workflows/azure-app-service.yml
+++ b/.github/workflows/azure-app-service.yml
@@ -75,11 +75,17 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
+      - name: 🛠️ Restore .NET tools
+        run: dotnet tool restore
+
       - name: 📦 Restore dependencies
         run: dotnet restore ./LearnStack/LearnStack.csproj
 
       - name: 🔨 Build application
         run: dotnet build ./LearnStack/LearnStack.csproj --configuration Release --no-restore
+
+      - name: 🗃️ Verify database migrations
+        run: dotnet ef migrations has-pending-model-changes --project ./LearnStack/LearnStack.csproj --startup-project ./LearnStack/LearnStack.csproj --configuration Release --no-build
 
       - name: 🧪 Run tests (if any)
         run: dotnet test --no-build --verbosity normal

--- a/LearnStack/Data/ApplicationDbContextFactory.cs
+++ b/LearnStack/Data/ApplicationDbContextFactory.cs
@@ -1,5 +1,7 @@
+using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace LearnStack.Data;
 
@@ -18,8 +20,14 @@ public class ApplicationDbContextFactory : IDesignTimeDbContextFactory<Applicati
             ?? throw new InvalidOperationException("Connection string 'DefaultConnection' not found.");
 
         var optionsBuilder = new DbContextOptionsBuilder<ApplicationDbContext>();
+        var applicationServiceProvider = new ServiceCollection()
+            .Configure<IdentityOptions>(options =>
+                options.Stores.SchemaVersion = IdentitySchemaVersions.Version3)
+            .BuildServiceProvider();
+
         optionsBuilder.UseSqlServer(connectionString, sql =>
-            sql.MigrationsAssembly(typeof(ApplicationDbContextFactory).Assembly.GetName().Name));
+                sql.MigrationsAssembly(typeof(ApplicationDbContextFactory).Assembly.GetName().Name))
+            .UseApplicationServiceProvider(applicationServiceProvider);
 
         return new ApplicationDbContext(optionsBuilder.Options);
     }

--- a/LearnStack/Data/Migrations/20260827175315_AddUserDisplayName.Designer.cs
+++ b/LearnStack/Data/Migrations/20260827175315_AddUserDisplayName.Designer.cs
@@ -4,6 +4,7 @@ using LearnStack.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace LearnStack.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260827175315_AddUserDisplayName")]
+    partial class AddUserDisplayName
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/LearnStack/Data/Migrations/20260827175315_AddUserDisplayName.cs
+++ b/LearnStack/Data/Migrations/20260827175315_AddUserDisplayName.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LearnStack.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserDisplayName : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "DisplayName",
+                table: "AspNetUsers",
+                type: "nvarchar(100)",
+                maxLength: 100,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DisplayName",
+                table: "AspNetUsers");
+        }
+    }
+}


### PR DESCRIPTION
The production App Service deployment succeeds, but ASP.NET Core exits with HTTP 500.30 because EF Core detects that `ApplicationUser.DisplayName` is not represented by a migration.

## What changed

- Add the `AddUserDisplayName` migration for the nullable `nvarchar(100)` column.
- Align the design-time DbContext factory with Identity schema version 3 so migration scaffolding preserves the passkey schema.
- Pin the EF Core CLI tool and make the deployment workflow reject pending model changes before publishing.

## Deployment notes

The next deployment will apply the new migration during startup. The schema change is additive and preserves existing users and passkeys.