### PR TITLE
Improve new user onboarding with MudBlazor stepper

### DIFF
--- a/LearnStack/Components/Layout/MainLayout.razor
+++ b/LearnStack/Components/Layout/MainLayout.razor
@@ -308,7 +308,36 @@
                 CloseOnEscapeKey = false
             });
 
-        await dialog.Result;
+        var result = await dialog.Result;
+        if (result is { Canceled: false, Data: true })
+        {
+            await OpenFirstResourceDialogAsync(user.Id);
+        }
+    }
+
+    private async Task OpenFirstResourceDialogAsync(string userId)
+    {
+        var parameters = new DialogParameters
+        {
+            { nameof(ResourceForm.UserId), userId }
+        };
+        var options = new DialogOptions
+        {
+            CloseButton = true,
+            MaxWidth = MaxWidth.Medium,
+            FullWidth = true
+        };
+
+        var dialog = await DialogService.ShowAsync<ResourceForm>(
+            L["AddLearningResourceDialog"],
+            parameters,
+            options);
+        var result = await dialog.Result;
+
+        if (result is { Canceled: false })
+        {
+            NavigationManager.NavigateTo("/resources", forceLoad: true);
+        }
     }
 
     private string GetUserInitials(string? name)

--- a/LearnStack/Components/Shared/OnboardingDialog.razor
+++ b/LearnStack/Components/Shared/OnboardingDialog.razor
@@ -1,114 +1,159 @@
-@using MudBlazor
+@using Microsoft.AspNetCore.Components.Authorization
 @using Microsoft.AspNetCore.Identity
 @using LearnStack.Data
-@using Microsoft.AspNetCore.Components.Authorization
-@inject UserManager<ApplicationUser> UserManager
 @inject AuthenticationStateProvider AuthenticationStateProvider
+@inject ISnackbar Snackbar
+@inject UserManager<ApplicationUser> UserManager
 
-<MudDialog Options="@_dialogOptions">
+<MudDialog Options="@DialogOptions">
     <TitleContent>
         <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
-            <MudIcon Icon="@Icons.Material.Filled.RocketLaunch" Color="Color.Primary" />
-            <MudText Typo="Typo.h6" Style="font-weight: 700;">@L["OnboardingTitle"]</MudText>
+            <span class="onboarding-mark" aria-hidden="true">
+                <MudIcon Icon="@Icons.Material.Filled.AutoStories" Size="Size.Small" />
+            </span>
+            <MudStack Spacing="0">
+                <MudText Typo="Typo.overline" Class="onboarding-kicker">LEARNSTACK</MudText>
+                <MudText Typo="Typo.h6" Class="onboarding-dialog-title">@L["OnboardingTitle"]</MudText>
+            </MudStack>
         </MudStack>
     </TitleContent>
     <DialogContent>
-        <MudStepper @bind-ActiveIndex="_activeIndex" CompletedStepColor="Color.Success" CurrentStepColor="Color.Primary" CenterLabels="true">
-            <ChildContent>
-                @* Step 1: Welcome *@
-                <MudStep Title="@L["OnboardingWelcomeStep"]">
-                    <MudStack AlignItems="AlignItems.Center" Spacing="4" Class="pa-4">
-                        <MudIcon Icon="@Icons.Material.Filled.Celebration" Style="font-size: 4rem; color: var(--mud-palette-primary);" />
-                        <MudText Typo="Typo.h5" Align="Align.Center" Style="font-weight: 700;">
-                            @L["OnboardingWelcomeTitle"]
-                        </MudText>
-                        <MudText Typo="Typo.body1" Align="Align.Center" Style="color: var(--mud-palette-text-secondary); max-width: 480px;">
-                            @L["OnboardingWelcomeDescription"]
-                        </MudText>
-                    </MudStack>
-                </MudStep>
+        <div class="onboarding-shell">
+            <MudStepper @bind-ActiveIndex="_activeIndex"
+                        Class="onboarding-stepper"
+                        StepClass="onboarding-step"
+                        CompletedStepColor="Color.Success"
+                        CurrentStepColor="Color.Primary"
+                        CenterLabels="true">
+                <ChildContent>
+                    <MudStep Title="@L["OnboardingWelcomeStep"]">
+                        <section class="onboarding-panel onboarding-panel-welcome">
+                            <div class="welcome-copy">
+                                <MudText Typo="Typo.overline" Class="panel-eyebrow">01 / @L["OnboardingWelcomeStep"]</MudText>
+                                <MudText Typo="Typo.h3" Class="panel-title">
+                                    @L["OnboardingWelcomeTitle"]
+                                </MudText>
+                                <MudText Typo="Typo.body1" Class="panel-description">
+                                    @L["OnboardingWelcomeDescription"]
+                                </MudText>
+                            </div>
 
-                @* Step 2: Resource Library *@
-                <MudStep Title="@L["OnboardingResourcesStep"]">
-                    <MudStack AlignItems="AlignItems.Center" Spacing="4" Class="pa-4">
-                        <div style="background: linear-gradient(135deg, #4f46e5, #818cf8); border-radius: 16px; padding: 16px; display: flex; align-items: center; justify-content: center;">
-                            <MudIcon Icon="@Icons.Material.Filled.AutoStories" Style="font-size: 3rem; color: white;" />
-                        </div>
-                        <MudText Typo="Typo.h5" Align="Align.Center" Style="font-weight: 700;">
-                            @L["OnboardingResourcesTitle"]
-                        </MudText>
-                        <MudText Typo="Typo.body1" Align="Align.Center" Style="color: var(--mud-palette-text-secondary); max-width: 480px;">
-                            @L["OnboardingResourcesDescription"]
-                        </MudText>
-                        <MudStack Row="true" Spacing="3" Justify="Justify.Center" Class="mt-2">
-                            <MudChip T="string" Icon="@Icons.Material.Filled.MenuBook" Color="Color.Primary" Variant="Variant.Text">@L["ToLearn"]</MudChip>
-                            <MudChip T="string" Icon="@Icons.Material.Filled.PlayCircle" Color="Color.Warning" Variant="Variant.Text">@L["InProgress"]</MudChip>
-                            <MudChip T="string" Icon="@Icons.Material.Filled.CheckCircle" Color="Color.Success" Variant="Variant.Text">@L["Completed"]</MudChip>
-                        </MudStack>
-                    </MudStack>
-                </MudStep>
+                            <div class="stack-illustration" aria-hidden="true">
+                                <div class="stack-card stack-card-back">
+                                    <MudIcon Icon="@Icons.Material.Filled.Podcasts" />
+                                    <span>24 min</span>
+                                </div>
+                                <div class="stack-card stack-card-middle">
+                                    <MudIcon Icon="@Icons.Material.Filled.PlayCircle" />
+                                    <span>@L["InProgress"]</span>
+                                </div>
+                                <div class="stack-card stack-card-front">
+                                    <MudIcon Icon="@Icons.Material.Filled.Article" />
+                                    <strong>@L["ToLearn"]</strong>
+                                    <span>learnstack.dev</span>
+                                </div>
+                            </div>
+                        </section>
+                    </MudStep>
 
-                @* Step 3: Friends *@
-                <MudStep Title="@L["OnboardingFriendsStep"]">
-                    <MudStack AlignItems="AlignItems.Center" Spacing="4" Class="pa-4">
-                        <div style="background: linear-gradient(135deg, #10b981, #34d399); border-radius: 16px; padding: 16px; display: flex; align-items: center; justify-content: center;">
-                            <MudIcon Icon="@Icons.Material.Filled.People" Style="font-size: 3rem; color: white;" />
-                        </div>
-                        <MudText Typo="Typo.h5" Align="Align.Center" Style="font-weight: 700;">
-                            @L["OnboardingFriendsTitle"]
-                        </MudText>
-                        <MudText Typo="Typo.body1" Align="Align.Center" Style="color: var(--mud-palette-text-secondary); max-width: 480px;">
-                            @L["OnboardingFriendsDescription"]
-                        </MudText>
-                    </MudStack>
-                </MudStep>
+                    <MudStep Title="@L["OnboardingResourcesStep"]">
+                        <section class="onboarding-panel">
+                            <MudText Typo="Typo.overline" Class="panel-eyebrow">02 / @L["OnboardingResourcesStep"]</MudText>
+                            <MudText Typo="Typo.h4" Class="panel-title">
+                                @L["OnboardingResourcesTitle"]
+                            </MudText>
+                            <MudText Typo="Typo.body1" Class="panel-description panel-description-wide">
+                                @L["OnboardingResourcesDescription"]
+                            </MudText>
 
-                @* Step 4: Shared Collections *@
-                <MudStep Title="@L["OnboardingSharedStep"]">
-                    <MudStack AlignItems="AlignItems.Center" Spacing="4" Class="pa-4">
-                        <div style="background: linear-gradient(135deg, #3b82f6, #60a5fa); border-radius: 16px; padding: 16px; display: flex; align-items: center; justify-content: center;">
-                            <MudIcon Icon="@Icons.Material.Filled.Share" Style="font-size: 3rem; color: white;" />
-                        </div>
-                        <MudText Typo="Typo.h5" Align="Align.Center" Style="font-weight: 700;">
-                            @L["OnboardingSharedTitle"]
-                        </MudText>
-                        <MudText Typo="Typo.body1" Align="Align.Center" Style="color: var(--mud-palette-text-secondary); max-width: 480px;">
-                            @L["OnboardingSharedDescription"]
-                        </MudText>
-                    </MudStack>
-                </MudStep>
+                            <div class="learning-path" aria-label="@L["Status"]">
+                                <div class="path-stage path-stage-primary">
+                                    <span class="path-number">1</span>
+                                    <MudIcon Icon="@Icons.Material.Filled.BookmarkAdd" />
+                                    <strong>@L["ToLearn"]</strong>
+                                </div>
+                                <MudIcon Icon="@Icons.Material.Filled.ArrowForward" Class="path-arrow" />
+                                <div class="path-stage path-stage-warning">
+                                    <span class="path-number">2</span>
+                                    <MudIcon Icon="@Icons.Material.Filled.PlayCircle" />
+                                    <strong>@L["InProgress"]</strong>
+                                </div>
+                                <MudIcon Icon="@Icons.Material.Filled.ArrowForward" Class="path-arrow" />
+                                <div class="path-stage path-stage-success">
+                                    <span class="path-number">3</span>
+                                    <MudIcon Icon="@Icons.Material.Filled.CheckCircle" />
+                                    <strong>@L["Completed"]</strong>
+                                </div>
+                            </div>
 
-                @* Step 5: Content Ideas *@
-                <MudStep Title="@L["OnboardingContentStep"]">
-                    <MudStack AlignItems="AlignItems.Center" Spacing="4" Class="pa-4">
-                        <div style="background: linear-gradient(135deg, #f59e0b, #fbbf24); border-radius: 16px; padding: 16px; display: flex; align-items: center; justify-content: center;">
-                            <MudIcon Icon="@Icons.Material.Filled.Lightbulb" Style="font-size: 3rem; color: white;" />
+                            <div class="resource-note">
+                                <MudIcon Icon="@Icons.Material.Filled.AutoAwesome" Size="Size.Small" />
+                                <span>@L["UrlHelperText"]</span>
+                            </div>
+                        </section>
+                    </MudStep>
+
+                    <MudStep Title="@L["OnboardingContentStep"]">
+                        <section class="onboarding-panel">
+                            <MudText Typo="Typo.overline" Class="panel-eyebrow">03 / @L["OnboardingContentStep"]</MudText>
+                            <MudText Typo="Typo.h4" Class="panel-title">
+                                @L["OnboardingContentTitle"]
+                            </MudText>
+                            <MudText Typo="Typo.body1" Class="panel-description panel-description-wide">
+                                @L["OnboardingContentDescription"]
+                            </MudText>
+
+                            <div class="feature-grid">
+                                <article class="feature-card feature-card-friends">
+                                    <span class="feature-icon">
+                                        <MudIcon Icon="@Icons.Material.Filled.People" />
+                                    </span>
+                                    <MudText Typo="Typo.subtitle1" Class="feature-title">@L["OnboardingFriendsTitle"]</MudText>
+                                    <MudText Typo="Typo.body2" Class="feature-copy">@L["OnboardingFriendsDescription"]</MudText>
+                                </article>
+                                <article class="feature-card feature-card-collections">
+                                    <span class="feature-icon">
+                                        <MudIcon Icon="@Icons.Material.Filled.CollectionsBookmark" />
+                                    </span>
+                                    <MudText Typo="Typo.subtitle1" Class="feature-title">@L["OnboardingSharedTitle"]</MudText>
+                                    <MudText Typo="Typo.body2" Class="feature-copy">@L["OnboardingSharedDescription"]</MudText>
+                                </article>
+                            </div>
+                        </section>
+                    </MudStep>
+                </ChildContent>
+                <CompletedContent>
+                    <section class="onboarding-complete">
+                        <div class="complete-orbit" aria-hidden="true">
+                            <span class="orbit-dot orbit-dot-one"></span>
+                            <span class="orbit-dot orbit-dot-two"></span>
+                            <span class="complete-icon">
+                                <MudIcon Icon="@Icons.Material.Filled.Check" />
+                            </span>
                         </div>
-                        <MudText Typo="Typo.h5" Align="Align.Center" Style="font-weight: 700;">
-                            @L["OnboardingContentTitle"]
+                        <MudText Typo="Typo.h4" Class="panel-title">
+                            @L["OnboardingCompleteTitle"]
                         </MudText>
-                        <MudText Typo="Typo.body1" Align="Align.Center" Style="color: var(--mud-palette-text-secondary); max-width: 480px;">
-                            @L["OnboardingContentDescription"]
+                        <MudText Typo="Typo.body1" Class="panel-description complete-description">
+                            @L["OnboardingCompleteDescription"]
                         </MudText>
-                    </MudStack>
-                </MudStep>
-            </ChildContent>
-            <CompletedContent>
-                <MudStack AlignItems="AlignItems.Center" Spacing="4" Class="pa-6">
-                    <MudIcon Icon="@Icons.Material.Filled.CheckCircle" Color="Color.Success" Style="font-size: 4rem;" />
-                    <MudText Typo="Typo.h5" Align="Align.Center" Style="font-weight: 700;">
-                        @L["OnboardingCompleteTitle"]
-                    </MudText>
-                    <MudText Typo="Typo.body1" Align="Align.Center" Style="color: var(--mud-palette-text-secondary); max-width: 480px;">
-                        @L["OnboardingCompleteDescription"]
-                    </MudText>
-                    <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="CompleteOnboarding"
-                              Size="Size.Large" Style="border-radius: 10px; font-weight: 600; padding: 12px 32px; text-transform: none;">
-                        @L["OnboardingGetStarted"]
-                    </MudButton>
-                </MudStack>
-            </CompletedContent>
-        </MudStepper>
+                        <MudButton Variant="Variant.Filled"
+                                   Color="Color.Primary"
+                                   StartIcon="@Icons.Material.Filled.AddLink"
+                                   OnClick="CompleteOnboardingAsync"
+                                   Disabled="@_isSaving"
+                                   Size="Size.Large"
+                                   Class="complete-button">
+                            @if (_isSaving)
+                            {
+                                <MudProgressCircular Indeterminate="true" Size="Size.Small" Class="mr-2" />
+                            }
+                            @L["AddFirstResource"]
+                        </MudButton>
+                    </section>
+                </CompletedContent>
+            </MudStepper>
+        </div>
     </DialogContent>
 </MudDialog>
 
@@ -117,8 +162,9 @@
     private IMudDialogInstance MudDialog { get; set; } = default!;
 
     private int _activeIndex;
+    private bool _isSaving;
 
-    private static readonly DialogOptions _dialogOptions = new()
+    private static readonly DialogOptions DialogOptions = new()
     {
         MaxWidth = MaxWidth.Medium,
         FullWidth = true,
@@ -127,14 +173,31 @@
         CloseOnEscapeKey = false
     };
 
-    private async Task CompleteOnboarding()
+    private async Task CompleteOnboardingAsync()
     {
+        if (_isSaving)
+        {
+            return;
+        }
+
+        _isSaving = true;
+
         var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
         var user = await UserManager.GetUserAsync(authState.User);
-        if (user is not null)
+        if (user is null)
         {
-            user.OnboardingCompletedAt = DateTime.UtcNow;
-            await UserManager.UpdateAsync(user);
+            Snackbar.Add(L["ErrorSubtitle"], Severity.Error);
+            _isSaving = false;
+            return;
+        }
+
+        user.OnboardingCompletedAt = DateTime.UtcNow;
+        var updateResult = await UserManager.UpdateAsync(user);
+        if (!updateResult.Succeeded)
+        {
+            Snackbar.Add(L["ErrorSubtitle"], Severity.Error);
+            _isSaving = false;
+            return;
         }
 
         MudDialog.Close(DialogResult.Ok(true));

--- a/LearnStack/Components/Shared/OnboardingDialog.razor.css
+++ b/LearnStack/Components/Shared/OnboardingDialog.razor.css
@@ -1,0 +1,386 @@
+.onboarding-mark {
+    align-items: center;
+    background: color-mix(in srgb, var(--mud-palette-primary) 14%, transparent);
+    border: 1px solid color-mix(in srgb, var(--mud-palette-primary) 28%, transparent);
+    border-radius: 12px;
+    color: var(--mud-palette-primary);
+    display: inline-flex;
+    height: 42px;
+    justify-content: center;
+    width: 42px;
+}
+
+.onboarding-kicker {
+    color: var(--mud-palette-primary);
+    font-size: .66rem;
+    font-weight: 800;
+    letter-spacing: .18em;
+    line-height: 1.2;
+}
+
+.onboarding-dialog-title {
+    font-family: ui-serif, Georgia, Cambria, "Times New Roman", serif;
+    font-weight: 700;
+    letter-spacing: -.02em;
+}
+
+.onboarding-shell {
+    background:
+        radial-gradient(circle at 92% 6%, color-mix(in srgb, var(--mud-palette-primary) 12%, transparent), transparent 28%),
+        linear-gradient(145deg, color-mix(in srgb, var(--mud-palette-surface) 94%, var(--mud-palette-primary) 6%), var(--mud-palette-surface));
+    border: 1px solid var(--mud-palette-lines-default);
+    border-radius: 22px;
+    overflow: hidden;
+}
+
+.onboarding-shell ::deep .mud-stepper {
+    background: transparent;
+    box-shadow: none;
+}
+
+.onboarding-shell ::deep .mud-stepper-nav {
+    background: color-mix(in srgb, var(--mud-palette-surface) 82%, transparent);
+    border-bottom: 1px solid var(--mud-palette-lines-default);
+    padding: 16px 24px 14px;
+}
+
+.onboarding-shell ::deep .mud-step-label-icon {
+    box-shadow: 0 0 0 5px color-mix(in srgb, var(--mud-palette-primary) 8%, transparent);
+}
+
+.onboarding-shell ::deep .mud-stepper-content {
+    padding: 0;
+}
+
+.onboarding-shell ::deep .mud-stepper-actions {
+    border-top: 1px solid var(--mud-palette-lines-default);
+    padding: 14px 24px;
+}
+
+.onboarding-shell ::deep .mud-stepper-button-next,
+.onboarding-shell ::deep .mud-stepper-button-complete {
+    border-radius: 10px;
+    font-weight: 700;
+    padding-inline: 20px;
+}
+
+.onboarding-panel {
+    min-height: 390px;
+    padding: 42px 46px 38px;
+}
+
+.onboarding-panel-welcome {
+    align-items: center;
+    display: grid;
+    gap: 32px;
+    grid-template-columns: minmax(0, 1.15fr) minmax(210px, .85fr);
+}
+
+.panel-eyebrow {
+    color: var(--mud-palette-primary);
+    font-size: .7rem;
+    font-weight: 800;
+    letter-spacing: .16em;
+}
+
+.panel-title {
+    font-family: ui-serif, Georgia, Cambria, "Times New Roman", serif;
+    font-weight: 700;
+    letter-spacing: -.035em;
+    line-height: 1.08;
+    margin: 8px 0 14px;
+    text-wrap: balance;
+}
+
+.panel-description {
+    color: var(--mud-palette-text-secondary);
+    line-height: 1.7;
+    max-width: 410px;
+}
+
+.panel-description-wide {
+    max-width: 610px;
+}
+
+.stack-illustration {
+    height: 245px;
+    position: relative;
+}
+
+.stack-card {
+    border: 1px solid color-mix(in srgb, var(--mud-palette-primary) 24%, var(--mud-palette-lines-default));
+    border-radius: 18px;
+    box-shadow: 0 18px 38px rgba(15, 23, 42, .14);
+    display: flex;
+    flex-direction: column;
+    inset: 0;
+    justify-content: space-between;
+    padding: 20px;
+    position: absolute;
+}
+
+.stack-card-back {
+    background: color-mix(in srgb, var(--mud-palette-info) 14%, var(--mud-palette-surface));
+    color: var(--mud-palette-info);
+    transform: rotate(9deg) translate(16px, 3px) scale(.88);
+}
+
+.stack-card-middle {
+    background: color-mix(in srgb, var(--mud-palette-warning) 13%, var(--mud-palette-surface));
+    color: var(--mud-palette-warning-darken);
+    transform: rotate(-6deg) translate(-11px, 5px) scale(.94);
+}
+
+.stack-card-front {
+    background: var(--mud-palette-surface);
+    color: var(--mud-palette-primary);
+    transform: rotate(1deg) translateY(9px);
+}
+
+.stack-card-front strong {
+    color: var(--mud-palette-text-primary);
+    font-family: ui-serif, Georgia, Cambria, "Times New Roman", serif;
+    font-size: 1.25rem;
+}
+
+.stack-card span {
+    color: var(--mud-palette-text-secondary);
+    font-size: .78rem;
+}
+
+.learning-path {
+    align-items: center;
+    display: grid;
+    gap: 12px;
+    grid-template-columns: 1fr auto 1fr auto 1fr;
+    margin-top: 30px;
+}
+
+.path-stage {
+    align-items: center;
+    background: var(--mud-palette-surface);
+    border: 1px solid var(--mud-palette-lines-default);
+    border-radius: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    min-height: 130px;
+    padding: 20px 12px 16px;
+    position: relative;
+}
+
+.path-number {
+    border: 1px solid currentColor;
+    border-radius: 99px;
+    font-size: .65rem;
+    font-weight: 800;
+    padding: 2px 7px;
+    position: absolute;
+    right: 9px;
+    top: 9px;
+}
+
+.path-stage-primary {
+    color: var(--mud-palette-primary);
+}
+
+.path-stage-warning {
+    color: var(--mud-palette-warning-darken);
+}
+
+.path-stage-success {
+    color: var(--mud-palette-success);
+}
+
+.path-stage strong {
+    color: var(--mud-palette-text-primary);
+    font-size: .84rem;
+    text-align: center;
+}
+
+.path-arrow {
+    color: var(--mud-palette-text-disabled);
+}
+
+.resource-note {
+    align-items: center;
+    background: color-mix(in srgb, var(--mud-palette-primary) 8%, transparent);
+    border-radius: 10px;
+    color: var(--mud-palette-primary);
+    display: flex;
+    font-size: .8rem;
+    gap: 8px;
+    margin-top: 20px;
+    padding: 10px 12px;
+}
+
+.feature-grid {
+    display: grid;
+    gap: 16px;
+    grid-template-columns: 1fr 1fr;
+    margin-top: 28px;
+}
+
+.feature-card {
+    background: var(--mud-palette-surface);
+    border: 1px solid var(--mud-palette-lines-default);
+    border-radius: 18px;
+    padding: 22px;
+    position: relative;
+    transition: transform 180ms ease, border-color 180ms ease;
+}
+
+.feature-card:hover {
+    border-color: color-mix(in srgb, var(--mud-palette-primary) 40%, var(--mud-palette-lines-default));
+    transform: translateY(-3px);
+}
+
+.feature-card-friends {
+    box-shadow: inset 0 3px 0 color-mix(in srgb, var(--mud-palette-success) 70%, transparent);
+}
+
+.feature-card-collections {
+    box-shadow: inset 0 3px 0 color-mix(in srgb, var(--mud-palette-info) 70%, transparent);
+}
+
+.feature-icon {
+    align-items: center;
+    background: color-mix(in srgb, var(--mud-palette-primary) 10%, transparent);
+    border-radius: 12px;
+    color: var(--mud-palette-primary);
+    display: inline-flex;
+    height: 42px;
+    justify-content: center;
+    margin-bottom: 14px;
+    width: 42px;
+}
+
+.feature-title {
+    font-weight: 750;
+    margin-bottom: 7px;
+}
+
+.feature-copy {
+    color: var(--mud-palette-text-secondary);
+    line-height: 1.55;
+}
+
+.onboarding-complete {
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    min-height: 390px;
+    padding: 48px 46px 42px;
+    text-align: center;
+}
+
+.complete-orbit {
+    border: 1px dashed color-mix(in srgb, var(--mud-palette-success) 55%, transparent);
+    border-radius: 50%;
+    height: 96px;
+    margin-bottom: 12px;
+    position: relative;
+    width: 96px;
+}
+
+.complete-icon {
+    align-items: center;
+    background: var(--mud-palette-success);
+    border-radius: 50%;
+    box-shadow: 0 12px 30px color-mix(in srgb, var(--mud-palette-success) 35%, transparent);
+    color: var(--mud-palette-success-text);
+    display: flex;
+    height: 62px;
+    inset: 16px;
+    justify-content: center;
+    position: absolute;
+    width: 62px;
+}
+
+.orbit-dot {
+    background: var(--mud-palette-warning);
+    border-radius: 50%;
+    height: 8px;
+    position: absolute;
+    width: 8px;
+}
+
+.orbit-dot-one {
+    right: 8px;
+    top: 8px;
+}
+
+.orbit-dot-two {
+    bottom: 5px;
+    left: 12px;
+}
+
+.complete-description {
+    max-width: 500px;
+}
+
+.complete-button {
+    border-radius: 12px;
+    box-shadow: 0 10px 24px color-mix(in srgb, var(--mud-palette-primary) 24%, transparent);
+    font-weight: 750;
+    margin-top: 24px;
+    min-height: 48px;
+    padding-inline: 26px;
+}
+
+@media (max-width: 600px) {
+    .onboarding-shell ::deep .mud-stepper-nav {
+        padding-inline: 10px;
+    }
+
+    .onboarding-shell ::deep .mud-step-label-content {
+        display: none;
+    }
+
+    .onboarding-shell ::deep .mud-stepper-actions {
+        padding: 12px 14px;
+    }
+
+    .onboarding-panel,
+    .onboarding-complete {
+        min-height: 430px;
+        padding: 30px 22px;
+    }
+
+    .onboarding-panel-welcome {
+        display: block;
+    }
+
+    .stack-illustration {
+        height: 170px;
+        margin: 18px auto 0;
+        max-width: 230px;
+    }
+
+    .learning-path {
+        gap: 7px;
+    }
+
+    .path-stage {
+        min-height: 112px;
+        padding-inline: 7px;
+    }
+
+    .path-arrow {
+        font-size: 1rem;
+    }
+
+    .feature-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .feature-card {
+        padding: 16px;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .feature-card {
+        transition: none;
+    }
+}


### PR DESCRIPTION
New users currently receive a passive five-screen feature tour that ends before they take a useful action. This change streamlines the experience into a focused three-step journey and carries users directly into creating their first learning resource.

## Summary

- Redesign the MudBlazor stepper with responsive, accessible, theme-aware styling
- Introduce the resource lifecycle and the social/content workflows in a shorter guided flow
- Persist onboarding completion only after the Identity update succeeds, keeping the dialog open on failure
- Open the add-resource dialog immediately after onboarding and refresh the resource page after a successful save

## Validation

- `dotnet build .\LearnStack.sln --no-restore`
- Build succeeds with the existing `MUD0002` warning in `Pulse.razor`

Local runtime preview remains blocked by the repository's pre-existing EF Core pending-model-changes error.