### PR TITLE
Complete Content Idea service coverage

### DIFF
--- a/LearnStack.Core.Tests/Services/ContentIdeaServiceTests.cs
+++ b/LearnStack.Core.Tests/Services/ContentIdeaServiceTests.cs
@@ -5,170 +5,345 @@ namespace LearnStack.Core.Tests.Services;
 
 public class ContentIdeaServiceTests
 {
- private static readonly string UserId = Text('u', 's', 'e', 'r', '-', '1');
- private static readonly string OtherUserId = Text('u', 's', 'e', 'r', '-', '2');
+    private const string UserId = "user-1";
+    private const string OtherUserId = "user-2";
 
- private static Task<TestDbContextFactory> MakeFactory()
- => TestDbContextFactory.CreateAsync(UserId, OtherUserId);
+    private static Task<TestDbContextFactory> MakeFactory() =>
+        TestDbContextFactory.CreateAsync(UserId, OtherUserId);
 
- [Fact]
- public async Task CreateAsync_StoresAndReturnsIdea()
- {
- await using var factory = await MakeFactory();
- var svc = new ContentIdeaService(factory);
+    [Fact]
+    public void Constructor_WhenContextFactoryIsNull_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => new ContentIdeaService(null!));
+    }
 
- var idea = await svc.CreateAsync(MakeIdea(UserId, Text('T', 'e', 's', 't', ' ', 'i', 'd', 'e', 'a')));
+    [Fact]
+    public async Task CreateAsync_WhenIdeaIsNull_ThrowsArgumentNullException()
+    {
+        await using var factory = await MakeFactory();
+        var service = new ContentIdeaService(factory);
 
- Assert.True(idea.Id > 0);
+        await Assert.ThrowsAsync<ArgumentNullException>(() => service.CreateAsync(null!));
+    }
 
- var fetched = await svc.GetByIdAsync(idea.Id, UserId);
- Assert.NotNull(fetched);
- Assert.Equal(Text('T', 'e', 's', 't', ' ', 'i', 'd', 'e', 'a'), fetched.Title);
- }
+    [Fact]
+    public async Task CreateAsync_StoresAndReturnsIdea()
+    {
+        await using var factory = await MakeFactory();
+        var service = new ContentIdeaService(factory);
 
- [Fact]
- public async Task GetAllAsync_ReturnsOnlyIdeasForOwner()
- {
- await using var factory = await MakeFactory();
- var svc = new ContentIdeaService(factory);
+        var idea = await service.CreateAsync(MakeIdea(UserId, "Test idea"));
 
- await svc.CreateAsync(MakeIdea(UserId, Text('O', 'w', 'n', 'e', 'd', ' ', 'i', 'd', 'e', 'a')));
- await svc.CreateAsync(MakeIdea(OtherUserId, Text('O', 't', 'h', 'e', 'r', ' ', 'i', 'd', 'e', 'a')));
+        Assert.True(idea.Id > 0);
 
- var results = await svc.GetAllAsync(UserId);
+        var fetched = await service.GetByIdAsync(idea.Id, UserId);
+        Assert.NotNull(fetched);
+        Assert.Equal("Test idea", fetched.Title);
+    }
 
- Assert.Single(results);
- Assert.Equal(Text('O', 'w', 'n', 'e', 'd', ' ', 'i', 'd', 'e', 'a'), results[0].Title);
- }
+    [Fact]
+    public async Task GetAllAsync_ReturnsOnlyIdeasForOwnerInExpectedOrder()
+    {
+        await using var factory = await MakeFactory();
+        var service = new ContentIdeaService(factory);
+        var olderHighPriorityIdea = MakeIdea(UserId, "Older high priority");
+        olderHighPriorityIdea.Priority = Priority.High;
+        olderHighPriorityIdea.CustomOrder = 1;
+        olderHighPriorityIdea.DateCreated = DateTime.UtcNow.AddDays(-1);
+        var newerHighPriorityIdea = MakeIdea(UserId, "Newer high priority");
+        newerHighPriorityIdea.Priority = Priority.High;
+        newerHighPriorityIdea.CustomOrder = 1;
 
- [Fact]
- public async Task AddSourceResourceAsync_AddsLinkForOwnedEntities()
- {
- await using var factory = await MakeFactory();
- var svc = new ContentIdeaService(factory);
+        await service.CreateAsync(MakeIdea(UserId, "Medium priority"));
+        await service.CreateAsync(olderHighPriorityIdea);
+        await service.CreateAsync(newerHighPriorityIdea);
+        await service.CreateAsync(MakeIdea(OtherUserId, "Other user's idea"));
 
- var idea = await svc.CreateAsync(MakeIdea(UserId));
- var resource = await CreateResourceAsync(factory, MakeResource(UserId));
+        var results = await service.GetAllAsync(UserId);
 
- await svc.AddSourceResourceAsync(idea.Id, resource.Id, UserId);
+        Assert.Equal(
+            ["Newer high priority", "Older high priority", "Medium priority"],
+            results.Select(idea => idea.Title));
+    }
 
- var fetched = await svc.GetByIdAsync(idea.Id, UserId);
- Assert.NotNull(fetched);
- Assert.Single(fetched.SourceResources);
- Assert.Equal(resource.Id, fetched.SourceResources.Single().LearningResourceId);
- }
+    [Fact]
+    public async Task GetByIdAsync_WhenIdeaBelongsToAnotherUser_ReturnsNull()
+    {
+        await using var factory = await MakeFactory();
+        var service = new ContentIdeaService(factory);
+        var idea = await service.CreateAsync(MakeIdea(OtherUserId));
 
- [Fact]
- public async Task AddSourceResourceAsync_DoesNotDuplicateExistingLink()
- {
- await using var factory = await MakeFactory();
- var svc = new ContentIdeaService(factory);
+        var result = await service.GetByIdAsync(idea.Id, UserId);
 
- var idea = await svc.CreateAsync(MakeIdea(UserId));
- var resource = await CreateResourceAsync(factory, MakeResource(UserId));
+        Assert.Null(result);
+    }
 
- await svc.AddSourceResourceAsync(idea.Id, resource.Id, UserId);
- await svc.AddSourceResourceAsync(idea.Id, resource.Id, UserId);
+    [Fact]
+    public async Task UpdateAsync_UpdatesEditableFieldsWithoutChangingOwnershipOrCreationDate()
+    {
+        await using var factory = await MakeFactory();
+        var service = new ContentIdeaService(factory);
+        var original = MakeIdea(UserId);
+        original.DateCreated = DateTime.UtcNow.AddDays(-2);
+        await service.CreateAsync(original);
+        var update = MakeIdea(OtherUserId, "Updated idea");
+        update.Id = original.Id;
+        update.ContentType = ContentIdeaType.Video;
+        update.Description = "Updated description";
+        update.Outline = "Updated outline";
+        update.Status = IdeaStatus.Published;
+        update.Priority = Priority.High;
+        update.Notes = "Updated notes";
+        update.DatePublished = DateTime.UtcNow;
+        update.CustomOrder = 4;
 
- var fetched = await svc.GetByIdAsync(idea.Id, UserId);
- Assert.NotNull(fetched);
- Assert.Single(fetched.SourceResources);
- }
+        var result = await service.UpdateAsync(update, UserId);
 
- [Fact]
- public async Task RemoveSourceResourceAsync_RemovesOwnedLink()
- {
- await using var factory = await MakeFactory();
- var svc = new ContentIdeaService(factory);
+        Assert.NotNull(result);
+        Assert.Equal("Updated idea", result.Title);
+        Assert.Equal(ContentIdeaType.Video, result.ContentType);
+        Assert.Equal("Updated description", result.Description);
+        Assert.Equal("Updated outline", result.Outline);
+        Assert.Equal(IdeaStatus.Published, result.Status);
+        Assert.Equal(Priority.High, result.Priority);
+        Assert.Equal("Updated notes", result.Notes);
+        Assert.Equal(update.DatePublished, result.DatePublished);
+        Assert.Equal(4, result.CustomOrder);
+        Assert.Equal(UserId, result.UserId);
+        Assert.Equal(original.DateCreated, result.DateCreated);
+    }
 
- var idea = await svc.CreateAsync(MakeIdea(UserId));
- var resource = await CreateResourceAsync(factory, MakeResource(UserId));
- await svc.AddSourceResourceAsync(idea.Id, resource.Id, UserId);
+    [Fact]
+    public async Task UpdateAsync_WhenIdeaBelongsToAnotherUser_ReturnsNullAndLeavesIdeaUnchanged()
+    {
+        await using var factory = await MakeFactory();
+        var service = new ContentIdeaService(factory);
+        var idea = await service.CreateAsync(MakeIdea(OtherUserId, "Original"));
+        var update = MakeIdea(UserId, "Changed");
+        update.Id = idea.Id;
 
- await svc.RemoveSourceResourceAsync(idea.Id, resource.Id, UserId);
+        var result = await service.UpdateAsync(update, UserId);
 
- var fetched = await svc.GetByIdAsync(idea.Id, UserId);
- Assert.NotNull(fetched);
- Assert.Empty(fetched.SourceResources);
- }
+        Assert.Null(result);
+        var stored = await service.GetByIdAsync(idea.Id, OtherUserId);
+        Assert.NotNull(stored);
+        Assert.Equal("Original", stored.Title);
+    }
 
- [Fact]
- public async Task RemoveSourceResourceAsync_DoesNotRemoveLinkWhenResourceBelongsToAnotherUser()
- {
- await using var factory = await MakeFactory();
- var svc = new ContentIdeaService(factory);
+    [Fact]
+    public async Task UpdateAsync_WhenIdeaIsNull_ThrowsArgumentNullException()
+    {
+        await using var factory = await MakeFactory();
+        var service = new ContentIdeaService(factory);
 
- var idea = await svc.CreateAsync(MakeIdea(UserId));
- var otherUsersResource = await CreateResourceAsync(factory, MakeResource(OtherUserId, Text('O', 't', 'h', 'e', 'r', ' ', 'u', 's', 'e', 'r', 's', ' ', 'r', 'e', 's', 'o', 'u', 'r', 'c', 'e')));
- await CreateLinkAsync(factory, idea.Id, otherUsersResource.Id);
+        await Assert.ThrowsAsync<ArgumentNullException>(() => service.UpdateAsync(null!, UserId));
+    }
 
- await svc.RemoveSourceResourceAsync(idea.Id, otherUsersResource.Id, UserId);
+    [Fact]
+    public async Task DeleteAsync_RemovesOwnedIdea()
+    {
+        await using var factory = await MakeFactory();
+        var service = new ContentIdeaService(factory);
+        var idea = await service.CreateAsync(MakeIdea(UserId));
 
- var fetched = await svc.GetByIdAsync(idea.Id, UserId);
- Assert.NotNull(fetched);
- Assert.Single(fetched.SourceResources);
- }
+        var deleted = await service.DeleteAsync(idea.Id, UserId);
 
- [Fact]
- public async Task UpdateOrderAsync_UpdatesOnlyOwnedIdeas()
- {
- await using var factory = await MakeFactory();
- var svc = new ContentIdeaService(factory);
+        Assert.True(deleted);
+        Assert.Null(await service.GetByIdAsync(idea.Id, UserId));
+    }
 
- var first = await svc.CreateAsync(MakeIdea(UserId, Text('F', 'i', 'r', 's', 't')));
- var second = await svc.CreateAsync(MakeIdea(UserId, Text('S', 'e', 'c', 'o', 'n', 'd')));
- var other = await svc.CreateAsync(MakeIdea(OtherUserId, Text('O', 't', 'h', 'e', 'r')));
+    [Fact]
+    public async Task DeleteAsync_WhenIdeaBelongsToAnotherUser_ReturnsFalseAndLeavesIdea()
+    {
+        await using var factory = await MakeFactory();
+        var service = new ContentIdeaService(factory);
+        var idea = await service.CreateAsync(MakeIdea(OtherUserId));
 
- await svc.UpdateOrderAsync(UserId, [second.Id, other.Id, first.Id]);
+        var deleted = await service.DeleteAsync(idea.Id, UserId);
 
- var ownedIdeas = await svc.GetAllAsync(UserId);
- Assert.Equal(0, ownedIdeas.Single(ci => ci.Id == second.Id).CustomOrder);
- Assert.Equal(2, ownedIdeas.Single(ci => ci.Id == first.Id).CustomOrder);
+        Assert.False(deleted);
+        Assert.NotNull(await service.GetByIdAsync(idea.Id, OtherUserId));
+    }
 
- var otherIdea = await svc.GetByIdAsync(other.Id, OtherUserId);
- Assert.NotNull(otherIdea);
- Assert.Equal(0, otherIdea.CustomOrder);
- }
+    [Fact]
+    public async Task AddSourceResourceAsync_AddsLinkForOwnedEntities()
+    {
+        await using var factory = await MakeFactory();
+        var service = new ContentIdeaService(factory);
+        var idea = await service.CreateAsync(MakeIdea(UserId));
+        var resource = await CreateResourceAsync(factory, MakeResource(UserId));
 
- private static async Task<LearningResource> CreateResourceAsync(TestDbContextFactory factory, LearningResource resource)
- {
- await using var context = await factory.CreateDbContextAsync();
- context.LearningResources.Add(resource);
- await context.SaveChangesAsync();
- return resource;
- }
+        await service.AddSourceResourceAsync(idea.Id, resource.Id, UserId);
 
- private static async Task CreateLinkAsync(TestDbContextFactory factory, int ideaId, int resourceId)
- {
- await using var context = await factory.CreateDbContextAsync();
- context.ContentIdeaResources.Add(new ContentIdeaResource
- {
- ContentIdeaId = ideaId,
- LearningResourceId = resourceId
- });
- await context.SaveChangesAsync();
- }
+        var fetched = await service.GetByIdAsync(idea.Id, UserId);
+        Assert.NotNull(fetched);
+        var link = Assert.Single(fetched.SourceResources);
+        Assert.Equal(resource.Id, link.LearningResourceId);
+        Assert.Equal(resource.Title, link.LearningResource?.Title);
+    }
 
- private static ContentIdea MakeIdea(string userId, string? title = null) =>
- new()
- {
- UserId = userId,
- Title = title ?? Text('I', 'd', 'e', 'a'),
- ContentType = ContentIdeaType.BlogPost,
- Status = IdeaStatus.Idea,
- Priority = Priority.Medium
- };
+    [Fact]
+    public async Task AddSourceResourceAsync_DoesNotDuplicateExistingLink()
+    {
+        await using var factory = await MakeFactory();
+        var service = new ContentIdeaService(factory);
+        var idea = await service.CreateAsync(MakeIdea(UserId));
+        var resource = await CreateResourceAsync(factory, MakeResource(UserId));
 
- private static LearningResource MakeResource(string userId, string? title = null) =>
- new()
- {
- UserId = userId,
- Title = title ?? Text('R', 'e', 's', 'o', 'u', 'r', 'c', 'e'),
- Url = Text('h', 't', 't', 'p', 's', ':', '/', '/', 'e', 'x', 'a', 'm', 'p', 'l', 'e', '.', 'c', 'o', 'm', '/') + Guid.NewGuid().ToString(Text('N')),
- ContentType = ContentType.BlogPost,
- Status = ContentStatus.ToLearn,
- Priority = Priority.Medium
- };
+        await service.AddSourceResourceAsync(idea.Id, resource.Id, UserId);
+        await service.AddSourceResourceAsync(idea.Id, resource.Id, UserId);
 
- private static string Text(params char[] chars) => new(chars);
+        var fetched = await service.GetByIdAsync(idea.Id, UserId);
+        Assert.NotNull(fetched);
+        Assert.Single(fetched.SourceResources);
+    }
+
+    [Fact]
+    public async Task AddSourceResourceAsync_WhenIdeaBelongsToAnotherUser_DoesNotAddLink()
+    {
+        await using var factory = await MakeFactory();
+        var service = new ContentIdeaService(factory);
+        var idea = await service.CreateAsync(MakeIdea(OtherUserId));
+        var resource = await CreateResourceAsync(factory, MakeResource(UserId));
+
+        await service.AddSourceResourceAsync(idea.Id, resource.Id, UserId);
+
+        var fetched = await service.GetByIdAsync(idea.Id, OtherUserId);
+        Assert.NotNull(fetched);
+        Assert.Empty(fetched.SourceResources);
+    }
+
+    [Fact]
+    public async Task AddSourceResourceAsync_WhenResourceBelongsToAnotherUser_DoesNotAddLink()
+    {
+        await using var factory = await MakeFactory();
+        var service = new ContentIdeaService(factory);
+        var idea = await service.CreateAsync(MakeIdea(UserId));
+        var resource = await CreateResourceAsync(factory, MakeResource(OtherUserId));
+
+        await service.AddSourceResourceAsync(idea.Id, resource.Id, UserId);
+
+        var fetched = await service.GetByIdAsync(idea.Id, UserId);
+        Assert.NotNull(fetched);
+        Assert.Empty(fetched.SourceResources);
+    }
+
+    [Fact]
+    public async Task RemoveSourceResourceAsync_RemovesOwnedLink()
+    {
+        await using var factory = await MakeFactory();
+        var service = new ContentIdeaService(factory);
+        var idea = await service.CreateAsync(MakeIdea(UserId));
+        var resource = await CreateResourceAsync(factory, MakeResource(UserId));
+        await service.AddSourceResourceAsync(idea.Id, resource.Id, UserId);
+
+        await service.RemoveSourceResourceAsync(idea.Id, resource.Id, UserId);
+
+        var fetched = await service.GetByIdAsync(idea.Id, UserId);
+        Assert.NotNull(fetched);
+        Assert.Empty(fetched.SourceResources);
+    }
+
+    [Fact]
+    public async Task RemoveSourceResourceAsync_WhenIdeaBelongsToAnotherUser_DoesNotRemoveLink()
+    {
+        await using var factory = await MakeFactory();
+        var service = new ContentIdeaService(factory);
+        var idea = await service.CreateAsync(MakeIdea(OtherUserId));
+        var resource = await CreateResourceAsync(factory, MakeResource(UserId));
+        await CreateLinkAsync(factory, idea.Id, resource.Id);
+
+        await service.RemoveSourceResourceAsync(idea.Id, resource.Id, UserId);
+
+        var fetched = await service.GetByIdAsync(idea.Id, OtherUserId);
+        Assert.NotNull(fetched);
+        Assert.Single(fetched.SourceResources);
+    }
+
+    [Fact]
+    public async Task RemoveSourceResourceAsync_WhenResourceBelongsToAnotherUser_DoesNotRemoveLink()
+    {
+        await using var factory = await MakeFactory();
+        var service = new ContentIdeaService(factory);
+        var idea = await service.CreateAsync(MakeIdea(UserId));
+        var resource = await CreateResourceAsync(factory, MakeResource(OtherUserId));
+        await CreateLinkAsync(factory, idea.Id, resource.Id);
+
+        await service.RemoveSourceResourceAsync(idea.Id, resource.Id, UserId);
+
+        var fetched = await service.GetByIdAsync(idea.Id, UserId);
+        Assert.NotNull(fetched);
+        Assert.Single(fetched.SourceResources);
+    }
+
+    [Fact]
+    public async Task UpdateOrderAsync_UpdatesOnlyOwnedIdeas()
+    {
+        await using var factory = await MakeFactory();
+        var service = new ContentIdeaService(factory);
+        var first = await service.CreateAsync(MakeIdea(UserId, "First"));
+        var second = await service.CreateAsync(MakeIdea(UserId, "Second"));
+        var other = await service.CreateAsync(MakeIdea(OtherUserId, "Other"));
+
+        await service.UpdateOrderAsync(UserId, [second.Id, other.Id, first.Id]);
+
+        var ownedIdeas = await service.GetAllAsync(UserId);
+        Assert.Equal(0, ownedIdeas.Single(idea => idea.Id == second.Id).CustomOrder);
+        Assert.Equal(2, ownedIdeas.Single(idea => idea.Id == first.Id).CustomOrder);
+
+        var otherIdea = await service.GetByIdAsync(other.Id, OtherUserId);
+        Assert.NotNull(otherIdea);
+        Assert.Equal(0, otherIdea.CustomOrder);
+    }
+
+    [Fact]
+    public async Task UpdateOrderAsync_WhenOrderedIdsIsNull_ThrowsArgumentNullException()
+    {
+        await using var factory = await MakeFactory();
+        var service = new ContentIdeaService(factory);
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() => service.UpdateOrderAsync(UserId, null!));
+    }
+
+    private static async Task<LearningResource> CreateResourceAsync(
+        TestDbContextFactory factory,
+        LearningResource resource)
+    {
+        await using var context = await factory.CreateDbContextAsync();
+        context.LearningResources.Add(resource);
+        await context.SaveChangesAsync();
+        return resource;
+    }
+
+    private static async Task CreateLinkAsync(TestDbContextFactory factory, int ideaId, int resourceId)
+    {
+        await using var context = await factory.CreateDbContextAsync();
+        context.ContentIdeaResources.Add(new ContentIdeaResource
+        {
+            ContentIdeaId = ideaId,
+            LearningResourceId = resourceId
+        });
+        await context.SaveChangesAsync();
+    }
+
+    private static ContentIdea MakeIdea(string userId, string title = "Idea") =>
+        new()
+        {
+            UserId = userId,
+            Title = title,
+            ContentType = ContentIdeaType.BlogPost,
+            Status = IdeaStatus.Idea,
+            Priority = Priority.Medium
+        };
+
+    private static LearningResource MakeResource(string userId, string title = "Resource") =>
+        new()
+        {
+            UserId = userId,
+            Title = title,
+            Url = $"https://example.com/{Guid.NewGuid():N}",
+            ContentType = ContentType.BlogPost,
+            Status = ContentStatus.ToLearn,
+            Priority = Priority.Medium
+        };
 }

--- a/LearnStack.Core/Services/ContentIdeaService.cs
+++ b/LearnStack.Core/Services/ContentIdeaService.cs
@@ -6,146 +6,155 @@ namespace LearnStack.Services;
 
 public class ContentIdeaService(IDbContextFactory<ApplicationDbContext> contextFactory) : IContentIdeaService
 {
- private readonly IDbContextFactory<ApplicationDbContext> _contextFactory = contextFactory;
+    private readonly IDbContextFactory<ApplicationDbContext> _contextFactory =
+        contextFactory ?? throw new ArgumentNullException(nameof(contextFactory));
 
- public async Task<List<ContentIdea>> GetAllAsync(string userId)
- {
- await using var context = await _contextFactory.CreateDbContextAsync();
- return await QueryIdeasWithSourceResources(context)
- .AsNoTracking()
- .Where(ci => ci.UserId == userId)
- .OrderByDescending(ci => ci.Priority)
- .ThenBy(ci => ci.CustomOrder)
- .ThenByDescending(ci => ci.DateCreated)
- .ToListAsync();
- }
+    public async Task<List<ContentIdea>> GetAllAsync(string userId)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync();
+        return await QueryIdeasWithSourceResources(context)
+            .AsNoTracking()
+            .Where(ci => ci.UserId == userId)
+            .OrderByDescending(ci => ci.Priority)
+            .ThenBy(ci => ci.CustomOrder)
+            .ThenByDescending(ci => ci.DateCreated)
+            .ToListAsync();
+    }
 
- public async Task<ContentIdea?> GetByIdAsync(int id, string userId)
- {
- await using var context = await _contextFactory.CreateDbContextAsync();
- return await QueryIdeasWithSourceResources(context)
- .AsNoTracking()
- .FirstOrDefaultAsync(ci => ci.Id == id && ci.UserId == userId);
- }
+    public async Task<ContentIdea?> GetByIdAsync(int id, string userId)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync();
+        return await QueryIdeasWithSourceResources(context)
+            .AsNoTracking()
+            .FirstOrDefaultAsync(ci => ci.Id == id && ci.UserId == userId);
+    }
 
- public async Task<ContentIdea> CreateAsync(ContentIdea idea)
- {
- await using var context = await _contextFactory.CreateDbContextAsync();
- context.ContentIdeas.Add(idea);
- await context.SaveChangesAsync();
- return idea;
- }
+    public async Task<ContentIdea> CreateAsync(ContentIdea idea)
+    {
+        ArgumentNullException.ThrowIfNull(idea);
 
- public async Task<ContentIdea?> UpdateAsync(ContentIdea idea, string userId)
- {
- await using var context = await _contextFactory.CreateDbContextAsync();
- var existing = await QueryOwnedIdeas(context, userId)
- .FirstOrDefaultAsync(ci => ci.Id == idea.Id);
- if (existing == null) return null;
+        await using var context = await _contextFactory.CreateDbContextAsync();
+        context.ContentIdeas.Add(idea);
+        await context.SaveChangesAsync();
+        return idea;
+    }
 
- ApplyUpdates(existing, idea);
+    public async Task<ContentIdea?> UpdateAsync(ContentIdea idea, string userId)
+    {
+        ArgumentNullException.ThrowIfNull(idea);
 
- await context.SaveChangesAsync();
- return existing;
- }
+        await using var context = await _contextFactory.CreateDbContextAsync();
+        var existing = await QueryOwnedIdeas(context, userId)
+            .FirstOrDefaultAsync(ci => ci.Id == idea.Id);
+        if (existing == null) return null;
 
- public async Task<bool> DeleteAsync(int id, string userId)
- {
- await using var context = await _contextFactory.CreateDbContextAsync();
- var idea = await QueryOwnedIdeas(context, userId)
- .FirstOrDefaultAsync(ci => ci.Id == id);
- if (idea == null) return false;
+        ApplyUpdates(existing, idea);
 
- context.ContentIdeas.Remove(idea);
- await context.SaveChangesAsync();
- return true;
- }
+        await context.SaveChangesAsync();
+        return existing;
+    }
 
- public async Task AddSourceResourceAsync(int ideaId, int resourceId, string userId)
- {
- await using var context = await _contextFactory.CreateDbContextAsync();
- if (!await IdeaExistsAsync(context, ideaId, userId) || !await ResourceExistsAsync(context, resourceId, userId))
- {
- return;
- }
+    public async Task<bool> DeleteAsync(int id, string userId)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync();
+        var idea = await QueryOwnedIdeas(context, userId)
+            .FirstOrDefaultAsync(ci => ci.Id == id);
+        if (idea == null) return false;
 
- var linkExists = await context.ContentIdeaResources
- .AnyAsync(cir => cir.ContentIdeaId == ideaId && cir.LearningResourceId == resourceId);
- if (linkExists) return;
+        context.ContentIdeas.Remove(idea);
+        await context.SaveChangesAsync();
+        return true;
+    }
 
- context.ContentIdeaResources.Add(new ContentIdeaResource
- {
- ContentIdeaId = ideaId,
- LearningResourceId = resourceId
- });
+    public async Task AddSourceResourceAsync(int ideaId, int resourceId, string userId)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync();
+        if (!await IdeaExistsAsync(context, ideaId, userId)
+            || !await ResourceExistsAsync(context, resourceId, userId))
+        {
+            return;
+        }
 
- await context.SaveChangesAsync();
- }
+        var linkExists = await context.ContentIdeaResources
+            .AnyAsync(cir => cir.ContentIdeaId == ideaId && cir.LearningResourceId == resourceId);
+        if (linkExists) return;
 
- public async Task RemoveSourceResourceAsync(int ideaId, int resourceId, string userId)
- {
- await using var context = await _contextFactory.CreateDbContextAsync();
- if (!await IdeaExistsAsync(context, ideaId, userId) || !await ResourceExistsAsync(context, resourceId, userId))
- {
- return;
- }
+        context.ContentIdeaResources.Add(new ContentIdeaResource
+        {
+            ContentIdeaId = ideaId,
+            LearningResourceId = resourceId
+        });
 
- var link = await context.ContentIdeaResources
- .FirstOrDefaultAsync(cir => cir.ContentIdeaId == ideaId && cir.LearningResourceId == resourceId);
- if (link == null) return;
+        await context.SaveChangesAsync();
+    }
 
- context.ContentIdeaResources.Remove(link);
- await context.SaveChangesAsync();
- }
+    public async Task RemoveSourceResourceAsync(int ideaId, int resourceId, string userId)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync();
+        if (!await IdeaExistsAsync(context, ideaId, userId)
+            || !await ResourceExistsAsync(context, resourceId, userId))
+        {
+            return;
+        }
 
- public async Task UpdateOrderAsync(string userId, List<int> orderedIds)
- {
- if (orderedIds.Count == 0)
- {
- return;
- }
+        var link = await context.ContentIdeaResources
+            .FirstOrDefaultAsync(cir => cir.ContentIdeaId == ideaId && cir.LearningResourceId == resourceId);
+        if (link == null) return;
 
- await using var context = await _contextFactory.CreateDbContextAsync();
+        context.ContentIdeaResources.Remove(link);
+        await context.SaveChangesAsync();
+    }
 
- var ideasById = await QueryOwnedIdeas(context, userId)
- .Where(ci => orderedIds.Contains(ci.Id))
- .ToDictionaryAsync(ci => ci.Id);
+    public async Task UpdateOrderAsync(string userId, List<int> orderedIds)
+    {
+        ArgumentNullException.ThrowIfNull(orderedIds);
 
- for (int i = 0; i < orderedIds.Count; i++)
- {
- if (ideasById.TryGetValue(orderedIds[i], out var idea))
- {
- idea.CustomOrder = i;
- }
- }
+        if (orderedIds.Count == 0)
+        {
+            return;
+        }
 
- await context.SaveChangesAsync();
- }
+        await using var context = await _contextFactory.CreateDbContextAsync();
 
- private static IQueryable<ContentIdea> QueryIdeasWithSourceResources(ApplicationDbContext context) =>
- context.ContentIdeas
- .Include(ci => ci.SourceResources)
- .ThenInclude(cir => cir.LearningResource);
+        var ideasById = await QueryOwnedIdeas(context, userId)
+            .Where(ci => orderedIds.Contains(ci.Id))
+            .ToDictionaryAsync(ci => ci.Id);
 
- private static IQueryable<ContentIdea> QueryOwnedIdeas(ApplicationDbContext context, string userId) =>
- context.ContentIdeas.Where(ci => ci.UserId == userId);
+        for (var i = 0; i < orderedIds.Count; i++)
+        {
+            if (ideasById.TryGetValue(orderedIds[i], out var idea))
+            {
+                idea.CustomOrder = i;
+            }
+        }
 
- private static Task<bool> IdeaExistsAsync(ApplicationDbContext context, int ideaId, string userId) =>
- QueryOwnedIdeas(context, userId).AnyAsync(ci => ci.Id == ideaId);
+        await context.SaveChangesAsync();
+    }
 
- private static Task<bool> ResourceExistsAsync(ApplicationDbContext context, int resourceId, string userId) =>
- context.LearningResources.AnyAsync(lr => lr.Id == resourceId && lr.UserId == userId);
+    private static IQueryable<ContentIdea> QueryIdeasWithSourceResources(ApplicationDbContext context) =>
+        context.ContentIdeas
+            .Include(ci => ci.SourceResources)
+            .ThenInclude(cir => cir.LearningResource);
 
- private static void ApplyUpdates(ContentIdea target, ContentIdea source)
- {
- target.Title = source.Title;
- target.ContentType = source.ContentType;
- target.Description = source.Description;
- target.Outline = source.Outline;
- target.Status = source.Status;
- target.Priority = source.Priority;
- target.Notes = source.Notes;
- target.DatePublished = source.DatePublished;
- target.CustomOrder = source.CustomOrder;
- }
+    private static IQueryable<ContentIdea> QueryOwnedIdeas(ApplicationDbContext context, string userId) =>
+        context.ContentIdeas.Where(ci => ci.UserId == userId);
+
+    private static Task<bool> IdeaExistsAsync(ApplicationDbContext context, int ideaId, string userId) =>
+        QueryOwnedIdeas(context, userId).AnyAsync(ci => ci.Id == ideaId);
+
+    private static Task<bool> ResourceExistsAsync(ApplicationDbContext context, int resourceId, string userId) =>
+        context.LearningResources.AnyAsync(lr => lr.Id == resourceId && lr.UserId == userId);
+
+    private static void ApplyUpdates(ContentIdea target, ContentIdea source)
+    {
+        target.Title = source.Title;
+        target.ContentType = source.ContentType;
+        target.Description = source.Description;
+        target.Outline = source.Outline;
+        target.Status = source.Status;
+        target.Priority = source.Priority;
+        target.Notes = source.Notes;
+        target.DatePublished = source.DatePublished;
+        target.CustomOrder = source.CustomOrder;
+    }
 }


### PR DESCRIPTION
Content Idea service behavior needs complete ownership and boundary coverage before it can safely support user-scoped CRUD and resource associations.

## Summary

- add defensive null validation for injected dependencies and mutation inputs
- preserve user ownership while updating, deleting, ordering, and associating source resources
- expand Content Idea service coverage from 7 to 19 tests across CRUD, sorting, authorization boundaries, duplicate links, and null inputs
- normalize the service and test formatting to repository conventions

## Validation

- `dotnet test .\LearnStack.Core.Tests\LearnStack.Core.Tests.csproj --no-restore --verbosity minimal` (58 passed)
- `dotnet build .\LearnStack.sln --no-restore --verbosity minimal`